### PR TITLE
Fixed app/assets/stylesheets references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add `font-awesome-sass-rails` gem to your `Gemfile`:
 
     gem 'font-awesome-sass-rails'
 
-Then add the stylesheet to your Rails assets. The simplest way to apply Font Awesome site-wide is to add a `require` statement in `app/assets/stylesheet/application.css`:
+Then add the stylesheet to your Rails assets. The simplest way to apply Font Awesome site-wide is to add a `require` statement in `app/assets/stylesheets/application.css`:
 
     *= require _font-awesome
 
@@ -20,7 +20,7 @@ If you want to manage where the stylesheet will be used or just prefer SCSS, you
 
     @import 'font-awesome';
 
-(By default Rails will import all SCSS files in `app/assets/stylesheet`, you can change this behavior by modifying `application.css`.)
+(By default Rails will import all SCSS files in `app/assets/stylesheets`, you can change this behavior by modifying `application.css`.)
 
 You can also use it with the SASS-converted Bootstrap gem, like [bootstrap-sass](https://github.com/thomas-mcdonald/bootstrap-sass) or [anjlab-bootstrap-rails](https://github.com/anjlab/bootstrap-rails). Just require/import font-awesome right after bootstrap.
 


### PR DESCRIPTION
Just noticed that the references to app/assets/stylesheets in the README had stylesheets singular. Thanks for the great gem!
